### PR TITLE
Fix paths defined in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "main": "./lib/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     },
     "./StyledTest.css": {
-      "style": "./dist/StyledTest.css",
-      "default": "./dist/StyledTest.css"
+      "style": "./lib/StyledTest.css",
+      "default": "./lib/StyledTest.css"
     }
   },
   "files": [


### PR DESCRIPTION
The export paths were referencing modules in a `dist` directory which does not exist. It should be `lib`.