### PR TITLE
Create AnnotationShareControl component

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.4.0",
+    "@hypothesis/frontend-shared": "^9.5.0",
     "@hypothesis/frontend-testing": "^1.7.1",
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-commonjs": "^28.0.0",

--- a/src/components/AnnotationShareControl.tsx
+++ b/src/components/AnnotationShareControl.tsx
@@ -146,10 +146,10 @@ export default function AnnotationShareControl({
         }
       >
         <div className="p-2 flex flex-col gap-y-2">
-          <h2 className="text-brand text-md font-medium">
+          <h2 className="text-brand text-[14px] font-medium">
             Share this annotation
           </h2>
-          <div className="flex w-full text-base">
+          <div className="flex w-full text-[13px]">
             <InputGroup>
               <Input
                 aria-label="Use this URL to share this annotation"
@@ -166,7 +166,7 @@ export default function AnnotationShareControl({
               />
             </InputGroup>
           </div>
-          <div className="text-base font-normal" data-testid="share-details">
+          <div className="text-[13px] font-normal" data-testid="share-details">
             {inContextAvailable ? (
               <>{annotationSharingInfo}</>
             ) : (

--- a/src/components/AnnotationShareControl.tsx
+++ b/src/components/AnnotationShareControl.tsx
@@ -11,11 +11,12 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import type { Group } from '../helpers';
 import type { Annotation } from '../helpers/annotation-metadata';
 import { isPrivate } from '../helpers/permissions';
+import type { Result } from '../utils/types';
 import { isIOS } from '../utils/user-agent';
 
 export type AnnotationShareControlProps = {
-  /** The annotation in question */
   annotation: Annotation;
+
   /** Group to which the annotation belongs */
   group: Group | null;
 
@@ -23,7 +24,7 @@ export type AnnotationShareControlProps = {
    * Invoked when the URI is copied to the clipboard.
    * It indicates if copying to the clipboard was successful or not.
    */
-  onCopy?: (result: { successful: boolean }) => void;
+  onCopy?: (result: Result<string, Error>) => void;
 };
 
 function selectionOverflowsInputElement() {
@@ -77,9 +78,9 @@ export default function AnnotationShareControl({
   const copyShareLink = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(shareURI!);
-      onCopy?.({ successful: true });
-    } catch {
-      onCopy?.({ successful: false });
+      onCopy?.({ ok: true, value: shareURI! });
+    } catch (error: any) {
+      onCopy?.({ ok: false, error });
     }
   }, [onCopy, shareURI]);
 

--- a/src/components/AnnotationShareControl.tsx
+++ b/src/components/AnnotationShareControl.tsx
@@ -1,0 +1,184 @@
+import {
+  CopyIcon,
+  IconButton,
+  Input,
+  InputGroup,
+  Popover,
+  ShareIcon,
+} from '@hypothesis/frontend-shared';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+
+import type { Group } from '../helpers';
+import type { Annotation } from '../helpers/annotation-metadata';
+import { isPrivate } from '../helpers/permissions';
+import { isIOS } from '../utils/user-agent';
+
+export type AnnotationShareControlProps = {
+  /** The annotation in question */
+  annotation: Annotation;
+  /** Group to which the annotation belongs */
+  group: Group | null;
+
+  /**
+   * Invoked when the URI is copied to the clipboard.
+   * It indicates if copying to the clipboard was successful or not.
+   */
+  onCopy?: (result: { successful: boolean }) => void;
+};
+
+function selectionOverflowsInputElement() {
+  // On iOS the selection overflows the input element
+  // See: https://github.com/hypothesis/client/pull/2799
+  return isIOS();
+}
+
+/**
+ * Retrieve an appropriate sharing link for this annotation.
+ *
+ * If the annotation is on a shareable document (i.e. its document is
+ * web-accessible), prefer the `incontext` (bouncer) link, but fallback to the
+ * `html` (single-annotation `h` web view) link if needed.
+ *
+ * If the annotation is not on a shareable document, don't use the `incontext`
+ * link as that won't work; only use the single-annotation-view `html` link.
+ *
+ * Note that `html` links are not provided by the service for third-party
+ * annotations.
+ */
+function annotationSharingLink(
+  annotation: Annotation,
+  isShareableURI: boolean,
+): string | null {
+  if (isShareableURI) {
+    return annotation.links?.incontext ?? annotation.links?.html ?? null;
+  } else {
+    return annotation.links?.html ?? null;
+  }
+}
+
+/**
+ * Share button which opens a Popover for sharing a single annotation.
+ */
+export default function AnnotationShareControl({
+  annotation,
+  group,
+  onCopy,
+}: AnnotationShareControlProps) {
+  const annotationIsPrivate = isPrivate(annotation.permissions);
+  const inContextAvailable = /^http(s?):/i.test(annotation.uri);
+  const shareURI = annotationSharingLink(annotation, inContextAvailable);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const shareRef = useRef<HTMLDivElement | null>(null);
+
+  const [isOpen, setOpen] = useState(false);
+  const wasOpen = useRef(isOpen);
+
+  const copyShareLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(shareURI!);
+      onCopy?.({ successful: true });
+    } catch {
+      onCopy?.({ successful: false });
+    }
+  }, [onCopy, shareURI]);
+
+  const toggleSharePanel = () => setOpen(prev => !prev);
+
+  useEffect(() => {
+    if (wasOpen.current !== isOpen) {
+      wasOpen.current = isOpen;
+
+      if (isOpen && !selectionOverflowsInputElement()) {
+        // Panel was just opened: select and focus the share URI for convenience
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    }
+  }, [isOpen]);
+
+  if (!group || !shareURI) {
+    return null;
+  }
+
+  // Generate some descriptive text about who may see the annotation if they
+  // follow the share link.
+  // First: Based on the type of the group the annotation is in, who would
+  // be able to view it?
+  const groupSharingInfo =
+    group.type === 'private' ? (
+      <span>
+        Only members of the group <em>{group.name}</em> may view this
+        annotation.
+      </span>
+    ) : (
+      <span>Anyone using this link may view this annotation.</span>
+    );
+
+  // However, if the annotation is marked as "only me" (`annotationIsPrivate` is `true`),
+  // then group sharing settings are irrelevant—only the author may view the
+  // annotation.
+  const annotationSharingInfo = annotationIsPrivate ? (
+    <span>Only you may view this annotation.</span>
+  ) : (
+    groupSharingInfo
+  );
+
+  return (
+    <div className="relative" ref={shareRef}>
+      <IconButton
+        icon={ShareIcon}
+        title="Share"
+        onClick={toggleSharePanel}
+        expanded={isOpen}
+      />
+      <Popover
+        open={isOpen}
+        onClose={() => setOpen(false)}
+        anchorElementRef={shareRef}
+        align="right"
+        placement="above"
+        arrow
+        classes={
+          // Set explicit width for browsers not supporting native popover API
+          // eslint-disable-next-line no-prototype-builtins
+          !HTMLElement.prototype.hasOwnProperty('popover') ? 'w-max' : undefined
+        }
+      >
+        <div className="p-2 flex flex-col gap-y-2">
+          <h2 className="text-brand text-md font-medium">
+            Share this annotation
+          </h2>
+          <div className="flex w-full text-base">
+            <InputGroup>
+              <Input
+                aria-label="Use this URL to share this annotation"
+                type="text"
+                value={shareURI}
+                readOnly
+                elementRef={inputRef}
+              />
+              <IconButton
+                icon={CopyIcon}
+                title="Copy share link to clipboard"
+                onClick={copyShareLink}
+                variant="dark"
+              />
+            </InputGroup>
+          </div>
+          <div className="text-base font-normal" data-testid="share-details">
+            {inContextAvailable ? (
+              <>{annotationSharingInfo}</>
+            ) : (
+              <>
+                This annotation cannot be shared in its original context because
+                it was made on a document that is not available on the web. This
+                link shares the annotation by itself.
+              </>
+            )}
+          </div>
+        </div>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as AnnotationDocumentInfo } from './AnnotationDocumentInfo';
 export { default as AnnotationGroupInfo } from './AnnotationGroupInfo';
+export { default as AnnotationShareControl } from './AnnotationShareControl';
 export { default as AnnotationTimestamps } from './AnnotationTimestamps';
 export { default as AnnotationUser } from './AnnotationUser';
 export { default as MarkdownView } from './MarkdownView';
@@ -8,6 +9,7 @@ export { default as StyledText } from './StyledText';
 
 export type { AnnotationDocumentInfoProps } from './AnnotationDocumentInfo';
 export type { AnnotationGroupInfoProps } from './AnnotationGroupInfo';
+export type { AnnotationShareControlProps } from './AnnotationShareControl';
 export type { AnnotationTimestampsProps } from './AnnotationTimestamps';
 export type { AnnotationUserProps } from './AnnotationUser';
 export type { MarkdownViewProps } from './MarkdownView';

--- a/src/components/test/AnnotationShareControl-test.js
+++ b/src/components/test/AnnotationShareControl-test.js
@@ -133,17 +133,19 @@ describe('AnnotationShareControl', () => {
       await getIconButton(wrapper, 'CopyIcon').props().onClick();
 
       assert.calledWith(fakeClipboardWriteText, 'https://www.example.com');
-      assert.calledWith(onCopy, { successful: true });
+      assert.calledWith(onCopy, { ok: true, value: 'https://www.example.com' });
     });
 
     it('indicates there was an error if copying was unsuccessful', () => {
-      fakeClipboardWriteText.throws(new Error('Error copying'));
+      const error = new Error('Error copying');
+      fakeClipboardWriteText.throws(error);
+
       const wrapper = createComponent({ onCopy });
       openElement(wrapper);
 
       getIconButton(wrapper, 'CopyIcon').props().onClick();
 
-      assert.calledWith(onCopy, { successful: false });
+      assert.calledWith(onCopy, { ok: false, error });
     });
   });
 

--- a/src/components/test/AnnotationShareControl-test.js
+++ b/src/components/test/AnnotationShareControl-test.js
@@ -1,0 +1,230 @@
+import {
+  checkAccessibility,
+  mockImportedComponents,
+} from '@hypothesis/frontend-testing';
+import { mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+import sinon from 'sinon';
+
+import AnnotationShareControl, { $imports } from '../AnnotationShareControl';
+
+describe('AnnotationShareControl', () => {
+  let fakeAnnotation;
+  let fakeGroup;
+  let fakeIsPrivate;
+  let fakeIsIOS;
+
+  const getIconButton = (wrapper, iconName) => {
+    return wrapper
+      .find('IconButton')
+      .filterWhere(n => n.find(iconName).exists());
+  };
+
+  function createComponent(props = {}) {
+    return mount(
+      <AnnotationShareControl
+        annotation={fakeAnnotation}
+        group={fakeGroup}
+        {...props}
+      />,
+      { connected: true },
+    );
+  }
+
+  function openElement(wrapper) {
+    act(() => {
+      wrapper.find('IconButton').props().onClick();
+    });
+    wrapper.update();
+  }
+
+  function isLinkInputFocused() {
+    return (
+      document.activeElement.getAttribute('aria-label') ===
+      'Use this URL to share this annotation'
+    );
+  }
+
+  beforeEach(() => {
+    fakeAnnotation = {
+      group: 'fakegroup',
+      permissions: {},
+      user: 'acct:bar@foo.com',
+      uri: 'http://www.example.com',
+      links: {
+        html: 'https://www.example.com',
+      },
+    };
+
+    fakeGroup = {
+      name: 'My Group',
+      type: 'private',
+    };
+    fakeIsPrivate = sinon.stub().returns(false);
+    fakeIsIOS = sinon.stub().returns(false);
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../helpers/permissions': { isPrivate: fakeIsPrivate },
+      '../utils/user-agent': { isIOS: fakeIsIOS },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('does not render component if annotation group is not available', () => {
+    const wrapper = createComponent({ group: null });
+    assert.equal(wrapper.html(), '');
+  });
+
+  it('toggles the share control element when the button is clicked', () => {
+    const wrapper = createComponent();
+    const button = getIconButton(wrapper, 'ShareIcon');
+
+    act(() => {
+      button.props().onClick();
+    });
+    wrapper.update();
+
+    assert.isTrue(wrapper.find('Popover').prop('open'));
+  });
+
+  it('closes the Popover when onClose is called', () => {
+    const wrapper = createComponent();
+    openElement(wrapper);
+
+    assert.isTrue(wrapper.find('Popover').prop('open'));
+    wrapper.find('Popover').props().onClose();
+    wrapper.update();
+    assert.isFalse(wrapper.find('Popover').prop('open'));
+  });
+
+  it('renders the share URI in a readonly input field', () => {
+    const expectedShareURI = 'https://hyp.is';
+    fakeAnnotation.links = { incontext: expectedShareURI };
+
+    const wrapper = createComponent();
+    openElement(wrapper);
+
+    const inputEl = wrapper.find('input');
+    assert.equal(inputEl.prop('value'), expectedShareURI);
+    assert.isTrue(inputEl.prop('readOnly'));
+  });
+
+  describe('copying the share URI to the clipboard', () => {
+    let onCopy;
+    let fakeClipboardWriteText;
+
+    beforeEach(() => {
+      onCopy = sinon.stub();
+      fakeClipboardWriteText = sinon.stub(navigator.clipboard, 'writeText');
+    });
+
+    afterEach(() => {
+      navigator.clipboard.writeText.restore();
+    });
+
+    it('copies the share link to the clipboard when the copy button is clicked', async () => {
+      const wrapper = createComponent({ onCopy });
+      openElement(wrapper);
+
+      await getIconButton(wrapper, 'CopyIcon').props().onClick();
+
+      assert.calledWith(fakeClipboardWriteText, 'https://www.example.com');
+      assert.calledWith(onCopy, { successful: true });
+    });
+
+    it('indicates there was an error if copying was unsuccessful', () => {
+      fakeClipboardWriteText.throws(new Error('Error copying'));
+      const wrapper = createComponent({ onCopy });
+      openElement(wrapper);
+
+      getIconButton(wrapper, 'CopyIcon').props().onClick();
+
+      assert.calledWith(onCopy, { successful: false });
+    });
+  });
+
+  [
+    {
+      groupType: 'private',
+      isPrivate: false,
+      expected: 'Only members of the group My Group may view this annotation.',
+    },
+    {
+      groupType: 'open',
+      isPrivate: false,
+      expected: 'Anyone using this link may view this annotation.',
+    },
+    {
+      groupType: 'private',
+      isPrivate: true,
+      expected: 'Only you may view this annotation.',
+    },
+    {
+      groupType: 'open',
+      isPrivate: true,
+      expected: 'Only you may view this annotation.',
+    },
+  ].forEach(({ groupType, isPrivate, expected }) => {
+    it(`renders the correct sharing information for a ${groupType} group when annotation privacy is ${isPrivate}`, () => {
+      fakeIsPrivate.returns(isPrivate);
+      fakeGroup.type = groupType;
+      const wrapper = createComponent({ group: fakeGroup });
+      openElement(wrapper);
+
+      const permissionsEl = wrapper.find('[data-testid="share-details"]');
+      assert.equal(permissionsEl.text(), expected);
+    });
+  });
+
+  it('renders an explanation if annotation cannot be shared in context', () => {
+    fakeAnnotation.uri = 'file:///some/local/file';
+    const wrapper = createComponent();
+    openElement(wrapper);
+
+    const detailsEl = wrapper.find('[data-testid="share-details"]');
+    assert.include(
+      detailsEl.text(),
+      'This annotation cannot be shared in its original context',
+    );
+  });
+
+  it('focuses the share-URI input when opened on non-iOS', () => {
+    const wrapper = createComponent();
+    openElement(wrapper);
+    wrapper.update();
+
+    assert.isTrue(isLinkInputFocused());
+  });
+
+  it("doesn't focus the share-URI input when opened on iOS", () => {
+    fakeIsIOS.returns(true);
+    const wrapper = createComponent();
+    openElement(wrapper);
+    wrapper.update();
+
+    assert.isFalse(isLinkInputFocused());
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility(
+      {
+        name: 'when closed',
+        content: () => createComponent(),
+      },
+      {
+        name: 'when open',
+        content: () => {
+          const wrapper = createComponent();
+          openElement(wrapper);
+          wrapper.update();
+          return wrapper;
+        },
+      },
+    ),
+  );
+});

--- a/src/helpers/annotation-metadata.ts
+++ b/src/helpers/annotation-metadata.ts
@@ -7,6 +7,14 @@ export type Annotation = {
     /** URL to view the annotation by itself. */
     html?: string;
   };
+  permissions: {
+    /** List of principals that can read the annotation */
+    read: string[];
+    /** List of principals that can edit the annotation */
+    update: string[];
+    /** List of principals that can delete the annotation */
+    delete: string[];
+  };
 };
 
 export type DocumentMetadata = {

--- a/src/helpers/permissions.ts
+++ b/src/helpers/permissions.ts
@@ -1,0 +1,10 @@
+import type { Annotation } from '../helpers/annotation-metadata';
+
+type Permissions = Annotation['permissions'];
+
+/**
+ * Return true if an annotation with the given permissions is private.
+ */
+export function isPrivate(perms: Permissions): boolean {
+  return !perms.read.some(principal => principal.startsWith('group:'));
+}

--- a/src/helpers/test/permissions-test.js
+++ b/src/helpers/test/permissions-test.js
@@ -1,0 +1,29 @@
+import { isPrivate } from '../permissions';
+
+describe('isPrivate', () => {
+  const userid = 'acct:flash@gord.on';
+
+  function privatePermissions(userid) {
+    return {
+      read: [userid],
+      update: [userid],
+      delete: [userid],
+    };
+  }
+
+  function sharedPermissions(userid, groupid) {
+    return Object.assign(privatePermissions(userid), {
+      read: ['group:' + groupid],
+    });
+  }
+
+  it('returns true if only specific users can read the annotation', () => {
+    const perms = privatePermissions(userid);
+    assert.isTrue(isPrivate(perms));
+  });
+
+  it('returns false if a group can read the annotation', () => {
+    const perms = sharedPermissions(userid, 'gid');
+    assert.isFalse(isPrivate(perms));
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {
   AnnotationDocumentInfo,
   AnnotationGroupInfo,
+  AnnotationShareControl,
   AnnotationTimestamps,
   AnnotationUser,
   StyledText,
@@ -13,6 +14,7 @@ export { renderMathAndMarkdown } from './utils';
 export type {
   AnnotationDocumentInfoProps,
   AnnotationGroupInfoProps,
+  AnnotationShareControlProps,
   AnnotationTimestampsProps,
   AnnotationUserProps,
   StyledTextProps,

--- a/src/utils/test/user-agent-test.js
+++ b/src/utils/test/user-agent-test.js
@@ -1,0 +1,25 @@
+import { isIOS } from '../user-agent';
+
+describe('isIOS', () => {
+  it('returns true when the user agent is an iOS', () => {
+    assert.isBoolean(isIOS()); // Test to check default parameters
+    assert.isTrue(
+      isIOS({ platform: 'iPad Simulator', userAgent: 'dummy' }, false),
+    );
+    assert.isTrue(
+      isIOS({ platform: 'iPhone Simulator', userAgent: 'dummy' }, false),
+    );
+    assert.isTrue(
+      isIOS({ platform: 'iPod Simulator', userAgent: 'dummy' }, false),
+    );
+    assert.isTrue(isIOS({ platform: 'iPad', userAgent: 'dummy' }, false));
+    assert.isTrue(isIOS({ platform: 'iPhone', userAgent: 'dummy' }, false));
+    assert.isTrue(isIOS({ platform: 'iPod', userAgent: 'dummy' }, false));
+    assert.isTrue(isIOS({ platform: 'dummy', userAgent: 'Mac' }, true));
+  });
+
+  it('returns false when the user agent is not an iOS', () => {
+    assert.isFalse(isIOS({ platform: 'dummy', userAgent: 'dummy' }, true));
+    assert.isFalse(isIOS({ platform: 'dummy', userAgent: 'Mac' }, false));
+  });
+});

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,13 @@
+/** Represents an operation that succeeded. */
+export type Success<T> = {
+  ok: true;
+  value: T;
+};
+
+/** Represents an operation that failed. */
+export type Failure<E> = {
+  ok: false;
+  error: E;
+};
+
+export type Result<T, E> = Success<T> | Failure<E>;

--- a/src/utils/user-agent.ts
+++ b/src/utils/user-agent.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns true when device is iOS.
+ * https://stackoverflow.com/a/9039885/14463679
+ */
+export const isIOS = (
+  _navigator: { platform: string; userAgent: string } = window.navigator,
+  _ontouchend: boolean = 'ontouchend' in document,
+): boolean => {
+  return (
+    [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod',
+    ].includes(_navigator.platform) ||
+    // iPad on iOS 13 detection
+    (_navigator.userAgent.includes('Mac') && _ontouchend)
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,7 +1643,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.4.0
+    "@hypothesis/frontend-shared": ^9.5.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-commonjs": ^28.0.0
@@ -1727,15 +1727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.4.0":
-  version: 9.4.0
-  resolution: "@hypothesis/frontend-shared@npm:9.4.0"
+"@hypothesis/frontend-shared@npm:^9.5.0":
+  version: 9.5.0
+  resolution: "@hypothesis/frontend-shared@npm:9.5.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 65a09edb7fae7b718909c00ccc2d2b6786b204540b93e7186af987f609b142350c9a8079d6bb67d366dff7da7a58b82c9543bc292cdf396d8a00d86c08556a94
+  checksum: 4295928ecb48f2896c3243de1e9e98373cf652c2ed269512092f3346b58edc98dc2f9b35c0002e5f0d2bdd0f39a770cf80a6d3709529afe2700f6097230c14ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9548

Depends on https://github.com/hypothesis/frontend-shared/pull/2000
Depends on https://github.com/hypothesis/frontend-shared/pull/2011

Add an `AnnotationShareControl` which renders an icon button that displays a popover when clicked.

![image](https://github.com/user-attachments/assets/f5e17481-13a3-4a2f-a8f8-f081f1a9954b)

The popover includes the annotation share URL and allows copying it to the clipboard.

This component is extracted from the client, to reuse in the moderation queue, in `h`. As opposed to the logic in client, this component can determine the annotation URL by itself, instead of expecting it to be provided by consumers.

> [!IMPORTANT]  
> The [second commit](https://github.com/hypothesis/annotation-ui/pull/30/commits/387ca2456b4559ba667cfdfc8c0ebc13fc315d5e) hardcodes some font sizes, to make sure the title is slightly bigger than the subtitle. The sizes set are the ones used for text-md and text-base in the client.
>
> Without those hardcoded sizes, the title looked smaller than the subtitle in h, because it does not define the font sizes in tailwind's config.
>
> I considered setting the font sizes to match the ones from the client, but:
> 1. It has a lot of side effects, reducing the font size everywhere.
> 2. It moves us in the wrong direction. The intention was to eventually increase the sidebar/client font sizes, not reduce the rest, so I don't think that was the right move.
>
> This ensures the component will look the same in the client, and at least have consistent sizes in h, even if they are slightly smaller than other texts.
> 
> Here's how it looks in h without the hardcoded font sizes
> ![image](https://github.com/user-attachments/assets/1246798f-9b4b-47c1-8db8-cc9f44fe0479)


### TODO

- [x] Make text size consistent