### PR TITLE
Change dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
-    time: "10:00"
+    interval: monthly
+    time: '10:00'
   open-pull-requests-limit: 10
   groups:
     babel:


### PR DESCRIPTION
To reduce the noise, decrease the frequency in which we get dependabot updates here to monthly.