### PR TITLE
Set explicit list style type for StyledText li

### DIFF
--- a/src/StyledText.css
+++ b/src/StyledText.css
@@ -75,8 +75,16 @@
             @apply list-outside list-disc ml-[1em];
         }
 
+        ul > li {
+            @apply list-disc;
+        }
+
         ol {
             @apply list-outside list-decimal ml-[1em];
+        }
+
+        ol > li {
+            @apply list-decimal;
         }
 
         ul > li,


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9671

The `StyledText.css` stylesheet defines the list style type for `ol` and `ul`, but not for `li`, assuming it will inherit the value based on where it is used.

This has caused in h, where we have resets for the three of them, to have lists display with no list style type:

![image](https://github.com/user-attachments/assets/8fa2757c-257e-4d22-a3db-b6cd839cfcc0)

This PR sets the list style type explicitly for `li`s as well, so that it overrides potential page style resets. With these changes, this is how it looks in h:

![image](https://github.com/user-attachments/assets/5af14d4f-fd17-4fa5-bcda-58152a6c3ae3)
