### PR TITLE
Add first moderation-related components and helpers

### DIFF
--- a/src/components/ModerationStatusSelect.tsx
+++ b/src/components/ModerationStatusSelect.tsx
@@ -1,0 +1,102 @@
+import type { IconComponent } from '@hypothesis/frontend-shared';
+import {
+  FilterIcon,
+  CautionIcon,
+  RestrictedIcon,
+  CheckAllIcon,
+  DottedCircleIcon,
+  Select,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { Fragment } from 'preact';
+
+import type { ModerationStatus } from '../helpers';
+import { moderationStatusToLabel } from '../helpers';
+
+export type ModerationStatusSelectProps = {
+  alignListbox?: 'right' | 'left';
+  disabled?: boolean;
+} & (
+  | {
+      /** This select is used to filter a list of annotations by moderation status */
+      mode: 'filter';
+      selected?: ModerationStatus;
+      onChange: (status?: ModerationStatus) => void;
+    }
+  | {
+      /** This select is used to set the moderation status of a specific annotation */
+      mode: 'select';
+      selected: ModerationStatus;
+      onChange: (status: ModerationStatus) => void;
+    }
+);
+
+type Option = {
+  icon: IconComponent;
+  label: string;
+};
+
+const options = new Map<ModerationStatus, Option>([
+  [
+    'PENDING',
+    { label: moderationStatusToLabel.PENDING, icon: DottedCircleIcon },
+  ],
+  ['APPROVED', { label: moderationStatusToLabel.APPROVED, icon: CheckAllIcon }],
+  ['DENIED', { label: moderationStatusToLabel.DENIED, icon: RestrictedIcon }],
+  ['SPAM', { label: moderationStatusToLabel.SPAM, icon: CautionIcon }],
+]);
+
+/**
+ * A Select component displaying the list of moderation statuses.
+ */
+export default function ModerationStatusSelect({
+  selected,
+  onChange,
+  mode,
+  alignListbox = 'right',
+  disabled,
+}: ModerationStatusSelectProps) {
+  const selectedName = selected ? options.get(selected)!.label : undefined;
+  const SelectedIcon = selected ? options.get(selected)!.icon : Fragment;
+
+  return (
+    <Select
+      value={selected}
+      // Cast to bypass TS warning that callback does not accept `undefined`.
+      // We will only include `undefined` in the options if `mode == "filter"`
+      // and this is allowed.
+      onChange={onChange as (value: ModerationStatus | undefined) => void}
+      alignListbox={alignListbox}
+      containerClasses="!w-auto"
+      buttonClasses={classnames(
+        mode === 'select' && {
+          '!bg-green-light !text-green-dark': selected === 'APPROVED',
+          '!bg-yellow-light !text-yellow-dark': selected === 'SPAM',
+          '!bg-red-light !text-red-dark': selected === 'DENIED',
+        },
+      )}
+      aria-label="Moderation status"
+      buttonContent={
+        <div className="flex gap-x-1.5 items-center">
+          {mode === 'filter' ? <FilterIcon /> : <SelectedIcon />}
+          {selectedName ?? 'All'}
+        </div>
+      }
+      disabled={disabled}
+    >
+      {mode === 'filter' && (
+        <Select.Option value={undefined} classes="text-grey-7">
+          All
+        </Select.Option>
+      )}
+      {[...options.entries()].map(([status, { label, icon: Icon }]) => (
+        <Select.Option key={status} value={status}>
+          <div className="flex gap-x-1.5 items-center text-grey-7">
+            <Icon />
+            {label}
+          </div>
+        </Select.Option>
+      ))}
+    </Select>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as AnnotationTimestamps } from './AnnotationTimestamps';
 export { default as AnnotationUser } from './AnnotationUser';
 export { default as MarkdownView } from './MarkdownView';
 export { default as MentionPopoverContent } from './MentionPopoverContent';
+export { default as ModerationStatusSelect } from './ModerationStatusSelect';
 export { default as StyledText } from './StyledText';
 
 export type { AnnotationDocumentInfoProps } from './AnnotationDocumentInfo';
@@ -14,4 +15,5 @@ export type { AnnotationTimestampsProps } from './AnnotationTimestamps';
 export type { AnnotationUserProps } from './AnnotationUser';
 export type { MarkdownViewProps } from './MarkdownView';
 export type { MentionPopoverContentProps } from './MentionPopoverContent';
+export type { ModerationStatusSelectProps } from './ModerationStatusSelect';
 export type { StyledTextProps } from './StyledText';

--- a/src/components/test/ModerationStatusSelect-test.js
+++ b/src/components/test/ModerationStatusSelect-test.js
@@ -1,0 +1,89 @@
+import {
+  checkAccessibility,
+  mount,
+  waitForElement,
+} from '@hypothesis/frontend-testing';
+import sinon from 'sinon';
+
+import ModerationStatusSelect from '../ModerationStatusSelect';
+
+describe('ModerationStatusSelect', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(props = {}) {
+    return mount(
+      <ModerationStatusSelect onChange={fakeOnChange} {...props} />,
+      { connected: true },
+    );
+  }
+
+  [
+    { selected: undefined, expectedText: 'All' },
+    { selected: 'PENDING', expectedText: 'Pending' },
+    { selected: 'APPROVED', expectedText: 'Approved' },
+    { selected: 'DENIED', expectedText: 'Declined' },
+    { selected: 'SPAM', expectedText: 'Spam' },
+  ].forEach(({ selected, expectedText }) => {
+    it('shows selected option as button content', () => {
+      const wrapper = createComponent({ selected });
+      assert.equal(wrapper.text(), expectedText);
+    });
+
+    it('calls onChange when changing selected item', () => {
+      const wrapper = createComponent();
+
+      assert.notCalled(fakeOnChange);
+      wrapper.find('Select').props().onChange(selected);
+      assert.calledWith(fakeOnChange, selected);
+    });
+  });
+
+  const commonOptions = ['Pending', 'Approved', 'Declined', 'Spam'];
+
+  [
+    { mode: 'filter', expectedOptions: ['All', ...commonOptions] },
+    { mode: 'select', expectedOptions: commonOptions },
+  ].forEach(({ mode, expectedOptions }) => {
+    it('shows expected list of options', async () => {
+      const wrapper = createComponent({ mode });
+
+      // Open listbox
+      wrapper.find('button').simulate('click');
+      const options = await waitForElement(wrapper, '[role="option"]');
+
+      assert.lengthOf(options, expectedOptions.length);
+      expectedOptions.forEach((option, index) => {
+        assert.equal(options.at(index).text(), option);
+      });
+    });
+  });
+
+  [
+    { mode: 'filter', expectedIcon: 'FilterIcon' },
+    { mode: 'select', selected: 'PENDING', expectedIcon: 'DottedCircleIcon' },
+    { mode: 'select', selected: 'APPROVED', expectedIcon: 'CheckAllIcon' },
+    { mode: 'select', selected: 'DENIED', expectedIcon: 'RestrictedIcon' },
+    { mode: 'select', selected: 'SPAM', expectedIcon: 'CautionIcon' },
+  ].forEach(({ mode, selected, expectedIcon }) => {
+    it('shows expected icon in toggle button', () => {
+      const wrapper = createComponent({ mode, selected });
+      assert.isTrue(wrapper.exists(expectedIcon));
+    });
+  });
+
+  [true, false].forEach(disabled => {
+    it('can be disabled', () => {
+      const wrapper = createComponent({ disabled });
+      assert.equal(wrapper.find('Select').prop('disabled'), disabled);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({ content: () => createComponent() }),
+  );
+});

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,11 @@
 export { documentMetadata } from './annotation-metadata';
 export { processAndReplaceMentionElements } from './mentions';
+export {
+  isModerationStatus,
+  moderationStatusToLabel,
+} from './moderation-status';
 
 export type { DocumentMetadata, DomainAndTitle } from './annotation-metadata';
 export type { Group, GroupType } from './groups';
 export type { Mention, MentionMode, InvalidMentionContent } from './mentions';
+export type { ModerationStatus } from './moderation-status';

--- a/src/helpers/moderation-status.ts
+++ b/src/helpers/moderation-status.ts
@@ -1,0 +1,19 @@
+export type ModerationStatus = 'PENDING' | 'APPROVED' | 'DENIED' | 'SPAM';
+
+export const moderationStatusToLabel: Record<ModerationStatus, string> = {
+  PENDING: 'Pending',
+  APPROVED: 'Approved',
+  DENIED: 'Declined',
+  SPAM: 'Spam',
+} as const;
+
+Object.freeze(moderationStatusToLabel);
+
+const moderationStatuses = Object.keys(moderationStatusToLabel);
+
+/**
+ * Whether provided status is a moderation status or not
+ */
+export const isModerationStatus = (
+  status: string,
+): status is ModerationStatus => moderationStatuses.includes(status);

--- a/src/helpers/test/moderation-status-test.js
+++ b/src/helpers/test/moderation-status-test.js
@@ -1,0 +1,16 @@
+import { isModerationStatus } from '../moderation-status';
+
+describe('isModerationStatus', () => {
+  [
+    { moderationStatus: 'foo', expectedResult: false },
+    { moderationStatus: 'bar', expectedResult: false },
+    { moderationStatus: 'PENDING', expectedResult: true },
+    { moderationStatus: 'APPROVED', expectedResult: true },
+    { moderationStatus: 'DENIED', expectedResult: true },
+    { moderationStatus: 'SPAM', expectedResult: true },
+  ].forEach(({ moderationStatus, expectedResult }) => {
+    it('returns true if provided value is a moderation status', () => {
+      assert.equal(isModerationStatus(moderationStatus), expectedResult);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,16 @@ export {
   AnnotationShareControl,
   AnnotationTimestamps,
   AnnotationUser,
-  StyledText,
   MarkdownView,
   MentionPopoverContent,
+  ModerationStatusSelect,
+  StyledText,
 } from './components';
-export { documentMetadata } from './helpers';
+export {
+  documentMetadata,
+  isModerationStatus,
+  moderationStatusToLabel,
+} from './helpers';
 export { renderMathAndMarkdown } from './utils';
 
 export type {
@@ -17,16 +22,18 @@ export type {
   AnnotationShareControlProps,
   AnnotationTimestampsProps,
   AnnotationUserProps,
-  StyledTextProps,
   MarkdownViewProps,
   MentionPopoverContentProps,
+  ModerationStatusSelectProps,
+  StyledTextProps,
 } from './components';
 export type {
   DocumentMetadata,
   DomainAndTitle,
   Group,
   GroupType,
+  InvalidMentionContent,
   Mention,
   MentionMode,
-  InvalidMentionContent,
+  ModerationStatus,
 } from './helpers';


### PR DESCRIPTION
Extract the `moderation-status` and `ModerationStatusSelect` from `h`, to use in the client as part of https://github.com/hypothesis/client/issues/7049 and https://github.com/hypothesis/client/issues/7050