### PR TITLE
Define reusable map for moderation status label and icon

### DIFF
--- a/src/components/ModerationStatusSelect.tsx
+++ b/src/components/ModerationStatusSelect.tsx
@@ -1,17 +1,9 @@
-import type { IconComponent } from '@hypothesis/frontend-shared';
-import {
-  FilterIcon,
-  CautionIcon,
-  RestrictedIcon,
-  CheckAllIcon,
-  DottedCircleIcon,
-  Select,
-} from '@hypothesis/frontend-shared';
+import { FilterIcon, Select } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { Fragment } from 'preact';
 
 import type { ModerationStatus } from '../helpers';
-import { moderationStatusToLabel } from '../helpers';
+import { moderationStatusInfo } from '../helpers';
 
 export type ModerationStatusSelectProps = {
   alignListbox?: 'right' | 'left';
@@ -31,21 +23,6 @@ export type ModerationStatusSelectProps = {
     }
 );
 
-type Option = {
-  icon: IconComponent;
-  label: string;
-};
-
-const options = new Map<ModerationStatus, Option>([
-  [
-    'PENDING',
-    { label: moderationStatusToLabel.PENDING, icon: DottedCircleIcon },
-  ],
-  ['APPROVED', { label: moderationStatusToLabel.APPROVED, icon: CheckAllIcon }],
-  ['DENIED', { label: moderationStatusToLabel.DENIED, icon: RestrictedIcon }],
-  ['SPAM', { label: moderationStatusToLabel.SPAM, icon: CautionIcon }],
-]);
-
 /**
  * A Select component displaying the list of moderation statuses.
  */
@@ -56,8 +33,12 @@ export default function ModerationStatusSelect({
   alignListbox = 'right',
   disabled,
 }: ModerationStatusSelectProps) {
-  const selectedName = selected ? options.get(selected)!.label : undefined;
-  const SelectedIcon = selected ? options.get(selected)!.icon : Fragment;
+  const selectedName = selected
+    ? moderationStatusInfo[selected]!.label
+    : undefined;
+  const SelectedIcon = selected
+    ? moderationStatusInfo[selected]!.icon
+    : Fragment;
 
   return (
     <Select
@@ -89,14 +70,16 @@ export default function ModerationStatusSelect({
           All
         </Select.Option>
       )}
-      {[...options.entries()].map(([status, { label, icon: Icon }]) => (
-        <Select.Option key={status} value={status}>
-          <div className="flex gap-x-1.5 items-center text-grey-7">
-            <Icon />
-            {label}
-          </div>
-        </Select.Option>
-      ))}
+      {Object.entries(moderationStatusInfo).map(
+        ([status, { label, icon: Icon }]) => (
+          <Select.Option key={status} value={status}>
+            <div className="flex gap-x-1.5 items-center text-grey-7">
+              <Icon />
+              {label}
+            </div>
+          </Select.Option>
+        ),
+      )}
     </Select>
   );
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,9 +1,6 @@
 export { documentMetadata } from './annotation-metadata';
 export { processAndReplaceMentionElements } from './mentions';
-export {
-  isModerationStatus,
-  moderationStatusToLabel,
-} from './moderation-status';
+export { isModerationStatus, moderationStatusInfo } from './moderation-status';
 
 export type { DocumentMetadata, DomainAndTitle } from './annotation-metadata';
 export type { Group, GroupType } from './groups';

--- a/src/helpers/moderation-status.ts
+++ b/src/helpers/moderation-status.ts
@@ -1,15 +1,30 @@
+import type { IconComponent } from '@hypothesis/frontend-shared';
+import {
+  CautionIcon,
+  CheckAllIcon,
+  DottedCircleIcon,
+  RestrictedIcon,
+} from '@hypothesis/frontend-shared';
+
 export type ModerationStatus = 'PENDING' | 'APPROVED' | 'DENIED' | 'SPAM';
 
-export const moderationStatusToLabel: Record<ModerationStatus, string> = {
-  PENDING: 'Pending',
-  APPROVED: 'Approved',
-  DENIED: 'Declined',
-  SPAM: 'Spam',
-} as const;
+/**
+ * Map of moderation statuses to their corresponding human-friendly label and
+ * icon
+ */
+export const moderationStatusInfo: Record<
+  ModerationStatus,
+  { label: string; icon: IconComponent }
+> = {
+  PENDING: { label: 'Pending', icon: DottedCircleIcon },
+  APPROVED: { label: 'Approved', icon: CheckAllIcon },
+  DENIED: { label: 'Declined', icon: RestrictedIcon },
+  SPAM: { label: 'Spam', icon: CautionIcon },
+};
 
-Object.freeze(moderationStatusToLabel);
+Object.freeze(moderationStatusInfo);
 
-const moderationStatuses = Object.keys(moderationStatusToLabel);
+const moderationStatuses = Object.keys(moderationStatusInfo);
 
 /**
  * Whether provided status is a moderation status or not

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
 export {
   documentMetadata,
   isModerationStatus,
-  moderationStatusToLabel,
+  moderationStatusInfo,
 } from './helpers';
 export { renderMathAndMarkdown } from './utils';
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/annotation-ui/pull/54

Following up on https://github.com/hypothesis/annotation-ui/pull/54, extract a reusable symbol that maps every moderation status to their corresponding label and icon, so that it can be used in places other than the `ModerationStatusSelect`.

The first use case for this is the moderation badge that needs to be created in client for https://github.com/hypothesis/client/issues/7049

The `ModerationSTatusSelect` has also been refactored to use it, so that the map is centralized in one place.