### PR TITLE
Make Excerpt modes more explicit and predictable

### DIFF
--- a/src/components/Excerpt.tsx
+++ b/src/components/Excerpt.tsx
@@ -5,10 +5,36 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
 import { observeElementSize } from '../utils/observe-element-size';
 
-type InlineControlsProps = {
+/**
+ * Providing these props indicates the Excerpt should work autonomously and
+ * provide its own toggle control.
+ */
+type InlineControlProps = {
+  /**
+   * The Excerpt is expected to be controlled internally. A collapse/expand
+   * control is implicitly rendered.
+   */
+  mode: 'inline-control';
+
+  /**
+   * Text on inline control when clicking it will collapse the content.
+   * Defaults to 'Less'.
+   */
+  collapseText?: string;
+
+  /**
+   * Text on inline control when clicking it will expand the content.
+   * Defaults to 'More'.
+   */
+  expandText?: string;
+
+  inlineControlStyle?: JSX.CSSProperties;
+  inlineControlClasses?: string | string[];
+};
+
+type InlineControlsProps = InlineControlProps & {
   isCollapsed: boolean;
   setCollapsed: (collapsed: boolean) => void;
-  linkStyle: JSX.CSSProperties;
 };
 
 /**
@@ -18,7 +44,10 @@ type InlineControlsProps = {
 function InlineControls({
   isCollapsed,
   setCollapsed,
-  linkStyle,
+  inlineControlStyle,
+  inlineControlClasses,
+  expandText = 'More',
+  collapseText = 'Less',
 }: InlineControlsProps) {
   return (
     <div
@@ -42,11 +71,12 @@ function InlineControls({
           onClick={() => setCollapsed(!isCollapsed)}
           expanded={!isCollapsed}
           title="Toggle visibility of full excerpt text"
-          style={linkStyle}
+          style={inlineControlStyle}
+          classes={inlineControlClasses}
           underline="always"
           inline
         >
-          {isCollapsed ? 'More' : 'Less'}
+          {isCollapsed ? expandText : collapseText}
         </LinkButton>
       </div>
     </div>
@@ -55,23 +85,40 @@ function InlineControls({
 
 const noop = () => {};
 
-export type ExcerptProps = {
-  children?: ComponentChildren;
-
+/**
+ * Providing these props indicates the Excerpt is externally controlled and no
+ * toggle is implicitly rendered.
+ */
+type ControlledExcerptProps = {
   /**
-   * If `true`, the excerpt provides internal controls to expand and collapse
-   * the content. If `false`, the caller sets the collapsed state via the
-   * `collapse` prop.  When using inline controls, the excerpt is initially
-   * collapsed.
+   * The Excerpt is expected to be controlled externally. No collapse/expand
+   * control is implicitly rendered
    */
-  inlineControls?: boolean;
+  mode: 'controlled';
 
   /**
    * If the content should be truncated if its height exceeds
    * `collapsedHeight + overflowThreshold`. This prop is only used if
    * `inlineControls` is false.
    */
-  collapse?: boolean;
+  collapsed: boolean;
+
+  /**
+   * When `inlineControls` is `false`, this function is called when the user
+   * requests to expand the content by clicking a zone at the bottom of the
+   * container.
+   */
+  onToggleCollapsed: (collapsed: boolean) => void;
+
+  /**
+   * Called when the content height exceeds or falls below
+   * `collapsedHeight + overflowThreshold`.
+   */
+  onCollapsibleChanged: (isCollapsible: boolean) => void;
+};
+
+export type ExcerptProps = {
+  children?: ComponentChildren;
 
   /**
    * Maximum height of the container, in pixels, when it is collapsed.
@@ -85,42 +132,34 @@ export type ExcerptProps = {
   overflowThreshold?: number;
 
   /**
-   * Called when the content height exceeds or falls below
-   * `collapsedHeight + overflowThreshold`.
+   * Whether a light collapse shadow should be displayed while collapsed,
+   * indicating more content is being currently hidden.
+   * Defaults to `true` in controlled Excerpts and `false` when using inline
+   * control.
    */
-  onCollapsibleChanged?: (isCollapsible: boolean) => void;
-
-  /**
-   * When `inlineControls` is `false`, this function is called when the user
-   * requests to expand the content by clicking a zone at the bottom of the
-   * container.
-   */
-  onToggleCollapsed?: (collapsed: boolean) => void;
-
-  /**
-   * Additional styles to pass to the inline controls element.
-   * Ignored if inlineControls is `false`.
-   */
-  inlineControlsLinkStyle?: JSX.CSSProperties;
-};
+  withCollapsedShadow?: boolean;
+} & (InlineControlProps | ControlledExcerptProps);
 
 /**
  * A container which truncates its content when they exceed a specified height.
  *
- * The collapsed state of the container can be handled either via internal
- * controls (if `inlineControls` is `true`) or by the caller using the
- * `collapse` prop.
+ * It can work in these `modes`:
+ * - inline-control: The collapsed state is handled by internal controls.
+ * - controlled: The collapsed state is handled by the caller.
  */
 export default function Excerpt({
   children,
-  collapse = false,
   collapsedHeight,
-  inlineControls = true,
-  onCollapsibleChanged = noop,
-  onToggleCollapsed = noop,
   overflowThreshold = 0,
-  inlineControlsLinkStyle = {},
+  ...rest
 }: ExcerptProps) {
+  const inlineControls = rest.mode === 'inline-control';
+  const withCollapsedShadow = rest.withCollapsedShadow ?? !inlineControls;
+  const {
+    onCollapsibleChanged = noop,
+    onToggleCollapsed = noop,
+    collapsed = true,
+  } = !inlineControls ? rest : {};
   const [collapsedByInlineControls, setCollapsedByInlineControls] =
     useState(true);
 
@@ -154,12 +193,12 @@ export default function Excerpt({
   // expanding/collapsing the content.
   // prettier-ignore
   const isOverflowing = contentHeight > (collapsedHeight + overflowThreshold);
-  const isCollapsed = inlineControls ? collapsedByInlineControls : collapse;
+  const isCollapsed = inlineControls ? collapsedByInlineControls : collapsed;
   const isExpandable = isOverflowing && isCollapsed;
 
-  const contentStyle: Record<string, number> = {};
+  const contentStyle: JSX.CSSProperties = {};
   if (contentHeight !== 0) {
-    contentStyle['max-height'] = isExpandable ? collapsedHeight : contentHeight;
+    contentStyle.maxHeight = isExpandable ? collapsedHeight : contentHeight;
   }
 
   const setCollapsed = (collapsed: boolean) =>
@@ -200,12 +239,12 @@ export default function Excerpt({
           'transition-[opacity] duration-150 ease-linear',
           'absolute w-full bottom-0 h-touch-minimum',
           {
-            // For expandable excerpts not using inlineControls, style this
+            // For expandable excerpts where the shadow was enabled, style this
             // element with a shadow-like gradient
             'bg-gradient-to-b from-white/0 via-95% via-black/10 to-100% to-black/15':
-              !inlineControls && isExpandable,
-            'bg-none': inlineControls,
-            // Don't make this shadow visible OR clickable if there's nothing
+              withCollapsedShadow && isExpandable,
+            'bg-none': !withCollapsedShadow && inlineControls,
+            // Don't make the shadow visible OR clickable if there's nothing
             // to do here (the excerpt isn't expandable)
             'opacity-0 pointer-events-none': !isExpandable,
           },
@@ -216,7 +255,7 @@ export default function Excerpt({
         <InlineControls
           isCollapsed={collapsedByInlineControls}
           setCollapsed={setCollapsed}
-          linkStyle={inlineControlsLinkStyle}
+          {...rest}
         />
       )}
     </div>

--- a/src/components/test/Excerpt-test.js
+++ b/src/components/test/Excerpt-test.js
@@ -15,14 +15,15 @@ describe('Excerpt', () => {
 
   let fakeObserveElementSize;
 
-  function createExcerpt(props = {}, content = DEFAULT_CONTENT) {
+  function createExcerpt(
+    { inlineControls, ...props } = {},
+    content = DEFAULT_CONTENT,
+  ) {
+    const modeProps = inlineControls
+      ? { mode: 'inline-control' }
+      : { mode: 'controlled', collapsed: true };
     return mount(
-      <Excerpt
-        collapse={true}
-        collapsedHeight={40}
-        inlineControls={false}
-        {...props}
-      >
+      <Excerpt collapsedHeight={40} {...modeProps} {...props}>
         {content}
       </Excerpt>,
       { connected: true },
@@ -43,9 +44,8 @@ describe('Excerpt', () => {
   });
 
   function getExcerptHeight(wrapper) {
-    return wrapper.find('[data-testid="excerpt-container"]').prop('style')[
-      'max-height'
-    ];
+    return wrapper.find('[data-testid="excerpt-container"]').prop('style')
+      .maxHeight;
   }
 
   it('renders content in container', () => {
@@ -154,6 +154,24 @@ describe('Excerpt', () => {
       button = getToggleButton(wrapper);
       assert.equal(button.prop('expanded'), true);
       assert.equal(button.text(), 'Less');
+    });
+
+    it('allows control text to be customized', () => {
+      const expandText = 'Expand';
+      const collapseText = 'Collapse';
+      const wrapper = createExcerpt(
+        {
+          inlineControls: true,
+          expandText,
+          collapseText,
+        },
+        TALL_DIV,
+      );
+
+      assert.equal(getToggleButton(wrapper).text(), expandText);
+      act(() => getToggleButton(wrapper).props().onClick());
+      wrapper.update();
+      assert.equal(getToggleButton(wrapper).text(), collapseText);
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/annotation-ui/pull/70

While working on https://github.com/hypothesis/h/issues/9808, we extracted the `Excerpt` component from the client to this library (see https://github.com/hypothesis/annotation-ui/pull/66), and started to use it there.

However, we found a few unintuitive or inconsistent behaviors in the component:

- The component has an `inlineControls` boolean prop to determine if it should implicitly provide a collapse/expand toggle, or consumers will provide their own.
- Other props can be passed, but depending on `inlineControls` being true or false, they may end up being ignored.
- When `inlineControls` is true, the implicit toggle is very opinionated and cannot be customized, except via CSS properties.
- When `inlineControls` is false, a drop shadow is displayed while collapsed, that helps see some content is hidden. There's no way to show this while `inlineControls` is true.

This PR changes the props API so that it is a union type with a discriminator property. That means there's a subset of common properties that can always be set, but then there's an exclusive set of properties that determine if the Excerpt is externally controlled or should render an inline toggle.

Controlled Excerpts expect these props:

```ts
/**
 * Providing these props indicates the Excerpt is externally controlled and no
 * toggle is implicitly rendered.
 */
type ControlledExcerptProps = {
  /**
   * The Excerpt is expected to be controlled externally. No collapse/expand
   * control is implicitly rendered
   */
  mode: 'controlled';

  /**
   * If the content should be truncated if its height exceeds
   * `collapsedHeight + overflowThreshold`. This prop is only used if
   * `inlineControls` is false.
   */
  collapsed: boolean;

  /**
   * When `inlineControls` is `false`, this function is called when the user
   * requests to expand the content by clicking a zone at the bottom of the
   * container.
   */
  onToggleCollapsed: (collapsed: boolean) => void;

  /**
   * Called when the content height exceeds or falls below
   * `collapsedHeight + overflowThreshold`.
   */
  onCollapsibleChanged: (isCollapsible: boolean) => void;
};
```

While inline-toggle Exceprts expect these:

```ts
/**
 * Providing these props indicates the Excerpt should work autonomously and
 * provide its own toggle control.
 */
type InlineControlProps = {
  /**
   * The Excerpt is expected to be controlled internally. A collapse/expand
   * control is implicitly rendered.
   */
  mode: 'inline-control';

  /**
   * Text on inline control when clicking it will collapse the content.
   * Defaults to 'Less'.
   */
  collapseText?: string;

  /**
   * Text on inline control when clicking it will expand the content.
   * Defaults to 'More'.
   */
  expandText?: string;

  inlineControlStyle?: JSX.CSSProperties;
  inlineControlClasses?: string | string[];
};
```

In both cases, a new `withCollapsedShadow?: boolean` prop is available, to render the drop shadow regardless the mode.

With this new approach:

* The mode in which the Excerpt will work has to be set explicitly, with the two existing modes supported for now, but the ability to add more if needed.
* All provided props will always have a use. There's no way of ending up setting a prop that gets accidentally ignored, since type checks will warn about this.
* The text of the inline control can be changed, allowing for a bit of customization without having to provide an external control.
* The inline control can be further customized via css classes, which is more convenient when working with tailwind.
* In controlled Excerpts, the `collapse` boolean prop has been renamed to `collapsed`, which sounds more natural.
* The shadow can be displayed in both controlled and inline Excerpts.

### Considerations

* This new approach does not support a mode in which the excerpt is controlled (state is handled externally and provided via props) but the toggle is still internally rendered. That was also an "issue" in previous approach, but now it's at least more explicit.
   However, we could add support for this mode if needed.

### Todo

- [x] Do not use custom tailwind classes that were available in the client only. (https://github.com/hypothesis/annotation-ui/pull/70)