### PR TITLE
Use standard tailwind classes for Excerpt shadow

### DIFF
--- a/src/components/Excerpt.tsx
+++ b/src/components/Excerpt.tsx
@@ -201,8 +201,8 @@ export default function Excerpt({
           'absolute w-full bottom-0 h-touch-minimum',
           {
             // For expandable excerpts not using inlineControls, style this
-            // element with a custom shadow-like gradient
-            'bg-gradient-to-b from-excerpt-stop-1 via-excerpt-stop-2 to-excerpt-stop-3':
+            // element with a shadow-like gradient
+            'bg-gradient-to-b from-white/0 via-95% via-black/10 to-100% to-black/15':
               !inlineControls && isExpandable,
             'bg-none': inlineControls,
             // Don't make this shadow visible OR clickable if there's nothing


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9808

When the Excerpt component was [brought here](https://github.com/hypothesis/annotation-ui/pull/66), I overlooked the fact that it was using a couple custom tailwind classes which behavior is defined in the client's tailwind config: https://github.com/hypothesis/client/blob/9860460/tailwind.config.js#L103-L109

In order to avoid the decision of where to put those now that the `Excerpt` component is part of a reusable library, this PR replaces them with standard tailwind classes which look almost exactly the same.