### PR TITLE
Add styles for disabled non-pending ModerationStatusSelect

### DIFF
--- a/src/components/ModerationStatusSelect.tsx
+++ b/src/components/ModerationStatusSelect.tsx
@@ -54,6 +54,9 @@ export default function ModerationStatusSelect({
           '!bg-green-light !text-green-dark': selected === 'APPROVED',
           '!bg-yellow-light !text-yellow-dark': selected === 'SPAM',
           '!bg-red-light !text-red-dark': selected === 'DENIED',
+          // The styles above override default select disabled styles, so let's
+          // add reduced opacity to those
+          'disabled:opacity-50': selected !== 'PENDING',
         },
       )}
       aria-label="Moderation status"


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9668

Fix disabled status in `ModerationStatusSelect` when mode is `select` and selected status is any other than `PENDING`.

Previously, they would look the same whether they were disabled or not. With these changes it has a lowered opacity that makes it more obvious that is disabled.

Before:
<img width="235" height="142" alt="image" src="https://github.com/user-attachments/assets/95fca966-b1c6-466e-b39c-1830643450af" />
<img width="235" height="142" alt="image" src="https://github.com/user-attachments/assets/ae82f44d-f4d2-43bd-adf7-8d29abd90446" />
<img width="235" height="142" alt="image" src="https://github.com/user-attachments/assets/ed261abd-8068-4f5c-a5c4-4ec40429deeb" />

After: 
<img width="235" height="142" alt="Captura desde 2025-08-26 17-54-47" src="https://github.com/user-attachments/assets/0528c175-3d10-4085-843c-68880d1b1aa2" />
<img width="235" height="142" alt="Captura desde 2025-08-26 17-55-08" src="https://github.com/user-attachments/assets/38d2a688-e4fa-47e4-aade-0e1ac47ef6cf" />
<img width="235" height="142" alt="Captura desde 2025-08-26 17-55-26" src="https://github.com/user-attachments/assets/14d8198b-cd40-4a1e-9373-6263aa3521c6" />
