### PR TITLE
Fix typo in StyledText export

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
       "import": "./lib/index.js",
       "types": "./lib/index.d.ts"
     },
-    "./StyledTest.css": {
-      "style": "./lib/StyledTest.css",
-      "default": "./lib/StyledTest.css"
+    "./StyledText.css": {
+      "style": "./lib/StyledText.css",
+      "default": "./lib/StyledText.css"
     }
   },
   "files": [


### PR DESCRIPTION
When migrating h to Tailwind v4 I discovered that this export was broken. It hasn't caused a problem until now because in h the StyledText.css file is currently imported directly from lib/StyledText.css by SASS. That will change as part of the TWv4 migration.