### PR TITLE
Use built-in `wrap-anywhere` utility

### DIFF
--- a/src/components/MarkdownView.tsx
+++ b/src/components/MarkdownView.tsx
@@ -199,7 +199,7 @@ export default function MarkdownView(props: MarkdownViewProps) {
   // a review in the future.
   return (
     <div
-      className={classnames('w-full break-anywhere cursor-text', {
+      className={classnames('w-full wrap-anywhere cursor-text', {
         // A `relative` wrapper around the `Popover` component is needed for
         // when the native Popover API is not supported.
         relative: mentionsEnabled,


### PR DESCRIPTION
Replace our custom `break-anywhere` utility with the built-in one available in Tailwind v4. See https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere.