### PR TITLE
Migrate Tailwind JS config to CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "gulp test"
   },
   "peerDependencies": {
-    "@hypothesis/frontend-shared": "^9.4.0",
+    "@hypothesis/frontend-shared": "^10.2.0",
     "dompurify": "^3.0.0",
     "escape-html": "^1.0.3",
     "katex": "^0.16.0",
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^4.1.0",
-    "@hypothesis/frontend-shared": "^10.0.0",
+    "@hypothesis/frontend-shared": "^10.2.0",
     "@hypothesis/frontend-testing": "^1.7.1",
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-commonjs": "^28.0.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,0 @@
-import tailwindConfig from '@hypothesis/frontend-shared/lib/tailwind.preset.js';
-
-export default {
-  presets: [tailwindConfig],
-  content: [
-    './src/components/**/*.{js,ts,tsx}',
-    './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
-  ],
-};

--- a/test/tailwind.css
+++ b/test/tailwind.css
@@ -1,5 +1,7 @@
-@import 'tailwindcss';
+@import 'tailwindcss' source(none);
 
-@config '../tailwind.config.js';
+@source '../node_modules/@hypothesis/frontend-shared/lib/**/*.js';
+@source '../src/components/**/*.{js,ts,tsx}';
 
+@import '@hypothesis/frontend-shared/tailwind-config.css';
 @import '../src/StyledText.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,7 +1749,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^4.1.0
-    "@hypothesis/frontend-shared": ^10.0.0
+    "@hypothesis/frontend-shared": ^10.2.0
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.0
     "@rollup/plugin-commonjs": ^28.0.0
@@ -1797,7 +1797,7 @@ __metadata:
     typescript-eslint: ^8.10.0
     vitest: ^3.1.1
   peerDependencies:
-    "@hypothesis/frontend-shared": ^9.4.0
+    "@hypothesis/frontend-shared": ^10.2.0
     dompurify: ^3.0.0
     escape-html: ^1.0.3
     katex: ^0.16.0
@@ -1835,15 +1835,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@hypothesis/frontend-shared@npm:10.0.0"
+"@hypothesis/frontend-shared@npm:^10.2.0":
+  version: 10.3.0
+  resolution: "@hypothesis/frontend-shared@npm:10.3.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: dfa8e3c137a10ca6ab8e725f7aa9d94766dd24395d60abdc1b3c4c710bbb1996f3d276536a5b3389222b06be7d6a986f4ab95f28b83277d6faec89c7d3a3639b
+  checksum: 3735e3b5e64e9444451e66e3fc648bcd0922aa7c6ad8a77c01ca2a599daf497696ad469596e33dbb926f24a87a37cd1f4ab463ba6eda41f80741240176054b7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Migrate the Tailwind config used in tests from JS to CSS, as this is the preferred way to configure Tailwind v4.